### PR TITLE
Bug/pushLead

### DIFF
--- a/Integration/AbstractEnhancerIntegration.php
+++ b/Integration/AbstractEnhancerIntegration.php
@@ -190,6 +190,8 @@ abstract class AbstractEnhancerIntegration extends AbstractIntegration
     /**
      * @param Lead  $lead
      * @param array $config
+     *
+     * @return bool
      */
     public function pushLead(Lead &$lead, array $config = [])
     {
@@ -209,6 +211,9 @@ abstract class AbstractEnhancerIntegration extends AbstractIntegration
         }
         $event = new MauticEnhancerEvent($this, $lead, $this->getCampaign());
         $this->dispatcher->dispatch(MauticEnhancerEvents::ENHANCER_COMPLETED, $event);
+
+        // Always return true to prevent campaign actions from being halted, even if an enhancer fails.
+        return true;
     }
 
     /**

--- a/Integration/AgeFromBirthdateIntegration.php
+++ b/Integration/AgeFromBirthdateIntegration.php
@@ -12,7 +12,6 @@
 namespace MauticPlugin\MauticEnhancerBundle\Integration;
 
 use DateTime;
-use Exception;
 use Mautic\LeadBundle\Entity\Lead;
 
 /**
@@ -100,9 +99,9 @@ class AgeFromBirthdateIntegration extends AbstractEnhancerIntegration
      */
     public function doEnhancement(Lead &$lead)
     {
-        //field name can be dynamic, with the field name picked up througn the config
-        // see the random plugin
-        try {
+        if (!empty($lead)) {
+            // Field name can be dynamic, with the field name picked up through the config
+            // see the random plugin.
             $dob = $lead->getFieldValue('afb_dob');
             if (isset($dob)) {
                 $today = new DateTime();
@@ -112,7 +111,6 @@ class AgeFromBirthdateIntegration extends AbstractEnhancerIntegration
                     $this->saveLead($lead);
                 }
             }
-        } catch (Exception $e) {
         }
     }
 }

--- a/Integration/NonFreeEnhancerTrait.php
+++ b/Integration/NonFreeEnhancerTrait.php
@@ -16,8 +16,7 @@ namespace MauticPlugin\MauticEnhancerBundle\Integration;
  */
 trait NonFreeEnhancerTrait
 {
-
-    /** @var integer */
+    /** @var int */
     protected $cost_per_enhancement;
 
     /**

--- a/Integration/NonFreeEnhancerTrait.php
+++ b/Integration/NonFreeEnhancerTrait.php
@@ -16,6 +16,8 @@ namespace MauticPlugin\MauticEnhancerBundle\Integration;
  */
 trait NonFreeEnhancerTrait
 {
+
+    /** @var integer */
     protected $cost_per_enhancement;
 
     /**
@@ -25,7 +27,7 @@ trait NonFreeEnhancerTrait
     {
         if (!isset($this->cost_per_enhancement)) {
             $settings                   = $this->getIntegrationSettings()->getFeatureSettings();
-            $this->cost_per_enhancement = $settings['cost_per_enhancement'];
+            $this->cost_per_enhancement = !empty($settings['cost_per_enhancement']) ? $settings['cost_per_enhancement'] : 0;
         }
 
         return $this->cost_per_enhancement;

--- a/Integration/RandomIntegration.php
+++ b/Integration/RandomIntegration.php
@@ -95,10 +95,12 @@ class RandomIntegration extends AbstractEnhancerIntegration
      */
     public function doEnhancement(Lead &$lead)
     {
-        $settings = $this->getIntegrationSettings()->getFeatureSettings();
+        if (!empty($lead)) {
+            $settings = $this->getIntegrationSettings()->getFeatureSettings();
 
-        if (!$lead->getFieldValue($settings['random_field_name'])) {
-            $lead->{$settings['random_field_name']} = rand(1, 101);
+            if (!$lead->getFieldValue($settings['random_field_name'])) {
+                $lead->{$settings['random_field_name']} = rand(1, 101);
+            }
         }
     }
 }


### PR DESCRIPTION
When we do not return true the forward campaign progression will stop
as if the integration has failed, expecting an error even if there is
none. By always returning true we ensure the campaign will continue.