### PR TITLE
Update field labels.

### DIFF
--- a/Integration/AgeFromBirthdateIntegration.php
+++ b/Integration/AgeFromBirthdateIntegration.php
@@ -50,11 +50,11 @@ class AgeFromBirthdateIntegration extends AbstractEnhancerIntegration
     {
         return [
             'afb_age' => [
-                'label'  => 'Age (D.o.B.)',
+                'label'  => 'Age',
                 'type'   => 'number',
             ],
             'afb_dob' => [
-                'label'  => 'D.o.B.',
+                'label'  => 'Date of Birth',
                 'type'   => 'date',
             ],
         ];

--- a/Integration/AlcazarIntegration.php
+++ b/Integration/AlcazarIntegration.php
@@ -165,31 +165,31 @@ class AlcazarIntegration extends AbstractEnhancerIntegration implements NonFreeE
     {
         return [
             'alcazar_spid'         => [
-                'label'  => 'SPID',
+                'label'  => 'Alcazar SPID',
             ],
             'alcazar_ocn'          => [
-                'label'  => 'OCN',
+                'label'  => 'Alcazar OCN',
             ],
             'alcazar_lata'         => [
-                'label'  => 'LATA',
+                'label'  => 'Alcazar LATA',
             ],
             'alcazar_city'         => [
-                'label'  => 'CITY',
+                'label'  => 'Alcazar City',
             ],
             'alcazar_state'        => [
-                'label'  => 'STATE',
+                'label'  => 'Alcazar State',
             ],
             'alcazar_lec'          => [
-                'label'  => 'LEC',
+                'label'  => 'Alcazar LEC',
             ],
             'alcazar_linetype'     => [
-                'label'  => 'LINETYPE',
+                'label'  => 'Alcazar Line Type',
             ],
             'alcazar_dnc'          => [
-                'label'  => 'DNC',
+                'label'  => 'Alcazar DNC',
             ],
             'alcazar_jurisdiction' => [
-                'label'  => 'JURISDICTION',
+                'label'  => 'Alcazar Jurisdiction',
             ],
         ];
     }


### PR DESCRIPTION
Some of these are easy to confuse with other fields in our system. For
example the “DNC” would get confused with the global DNC, so I prefixed
it with Alcazar.