### PR TITLE
Prevent notices/warnings due to new fields being added without required properties.

### DIFF
--- a/Integration/AbstractEnhancerIntegration.php
+++ b/Integration/AbstractEnhancerIntegration.php
@@ -57,6 +57,14 @@ abstract class AbstractEnhancerIntegration extends AbstractIntegration
                 //setting extendedField/lead in one place,
                 $new_field->setObject($this->getLeadFieldObject());
 
+                // Add default required properties to prevent warnings and notices.
+                if (isset($properties['type'])) {
+                    if ('boolean' === $properties['type']) {
+                        $new_field->setProperties('a:2:{s:2:"no";s:2:"No";s:3:"yes";s:3:"Yes";}');
+                    } elseif ('number' === $properties['type']) {
+                        $new_field->setProperties('a:2:{s:9:"roundmode";s:1:"3";s:9:"precision";s:0:"";}');
+                    }
+                }
                 foreach ($properties as $property => $value) {
                     //convert snake case to cammel case
                     $method = 'set'.implode('', array_map('ucfirst', explode('_', $property)));

--- a/Integration/XverifyIntegration.php
+++ b/Integration/XverifyIntegration.php
@@ -103,19 +103,19 @@ class XverifyIntegration extends AbstractEnhancerIntegration implements NonFreeE
     {
         return [
             'email_valid'     => [
-                'label' => 'Xverify&quot;d Email',
+                'label' => 'Xverify Email Valid',
                 'type'  => 'boolean',
             ],
             'workphone_valid' => [
-                'label' => 'Xverify&quot;d Work Phone',
+                'label' => 'Xverify Work Phone Valid',
                 'type'  => 'boolean',
             ],
             'cellphone_valid' => [
-                'label' => 'Xverify&quot;d Mobile Phone',
+                'label' => 'Xverify Mobile Phone Valid',
                 'type'  => 'boolean',
             ],
             'homephone_valid' => [
-                'label' => 'Xverify&quot;d Home Phone',
+                'label' => 'Xverify Home Phone Valid',
                 'type'  => 'boolean',
             ],
         ];


### PR DESCRIPTION
Also correct xverify field name defaults.