### PR TITLE
Fix issue preventing the lead key from being set from when the lead was last active

### DIFF
--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -65,7 +65,7 @@ class LeadSubscriber extends CommonSubscriber
                     '|',
                     [
                         $lead->getFirstname(),
-                        $lead->getLastActive(),
+                        $lead->getLastActive()->format('Y-m-d H:i:s'),
                         $lead->getEmail(),
                         $lead->getPhone(),
                         $lead->getMobile(),

--- a/EventListener/LeadSubscriber.php
+++ b/EventListener/LeadSubscriber.php
@@ -65,7 +65,7 @@ class LeadSubscriber extends CommonSubscriber
                     '|',
                     [
                         $lead->getFirstname(),
-                        $lead->getLastActive()->format('Y-m-d H:i:s'),
+                        ($lead->getLastActive() ? $lead->getLastActive()->format('c') : ''),
                         $lead->getEmail(),
                         $lead->getPhone(),
                         $lead->getMobile(),


### PR DESCRIPTION
When attempting to set `$leadKey` in `EventListener/LeadSubscriber.php` the lead's last active date object was being referenced as a string throwing a fatal error. Not sure if this is the most ideal format for the last active date, but it was the most frequently used format I found across these projects.